### PR TITLE
Go cleanup

### DIFF
--- a/go/index.html.template
+++ b/go/index.html.template
@@ -23,8 +23,8 @@
 </div>
 <div>
     <h4>Server sent information :</h4>
-    <p>Instance id: {{.Instance_id}}</p>
-    <p>Instance index: {{.Instance_index}}</p>
+    <p>Instance ID: {{.InstanceID}}</p>
+    <p>Instance index: {{.InstanceIndex}}</p>
 </div>
 <footer>
     <div>

--- a/go/main.go
+++ b/go/main.go
@@ -7,14 +7,14 @@ import (
 	"os"
 )
 
-type vars struct {
+type instanceInfo struct {
 	InstanceID    string
 	InstanceIndex string
 }
 
+var info instanceInfo
+
 func IndexHandler(w http.ResponseWriter, r *http.Request) {
-	id := os.Getenv("CF_INSTANCE_GUID")
-	index := os.Getenv("CF_INSTANCE_INDEX")
 	f, err := ioutil.ReadFile("index.html.template")
 	if err != nil {
 		panic(err)
@@ -23,13 +23,18 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		panic(err)
 	}
-	err = tmpl.Execute(w, vars{InstanceID: id, InstanceIndex: index})
+	err = tmpl.Execute(w, info)
 	if err != nil {
 		panic(err)
 	}
 }
 
 func main() {
+	info = instanceInfo{
+		InstanceID:    os.Getenv("CF_INSTANCE_GUID"),
+		InstanceIndex: os.Getenv("CF_INSTANCE_INDEX"),
+	}
+
 	http.HandleFunc("/", IndexHandler)
 	http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(http.Dir("public"))))
 	http.ListenAndServe(":8080", nil)

--- a/go/main.go
+++ b/go/main.go
@@ -18,7 +18,7 @@ var (
 
 func IndexHandler(w http.ResponseWriter, r *http.Request) {
 	if err := tmpl.Execute(w, info); err != nil {
-		panic(err)
+		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 

--- a/go/main.go
+++ b/go/main.go
@@ -28,7 +28,7 @@ func main() {
 		InstanceIndex: os.Getenv("CF_INSTANCE_INDEX"),
 	}
 
-	tmpl = template.Must(template.ParseFiles("index.html.template"))
+	tmpl = template.Must(template.New("goose").Parse(gooseTemplate))
 
 	http.HandleFunc("/", IndexHandler)
 	http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(http.Dir("public"))))

--- a/go/main.go
+++ b/go/main.go
@@ -16,7 +16,7 @@ var (
 	tmpl *template.Template
 )
 
-func IndexHandler(w http.ResponseWriter, r *http.Request) {
+func indexHandler(w http.ResponseWriter, r *http.Request) {
 	if err := tmpl.Execute(w, info); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
@@ -30,7 +30,7 @@ func main() {
 
 	tmpl = template.Must(template.New("goose").Parse(gooseTemplate))
 
-	http.HandleFunc("/", IndexHandler)
+	http.HandleFunc("/", indexHandler)
 	http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(http.Dir("public"))))
 	http.ListenAndServe(":8080", nil)
 }

--- a/go/main.go
+++ b/go/main.go
@@ -7,24 +7,23 @@ import (
 	"os"
 )
 
-type index_vars struct {
-	Instance_id    string
-	Instance_index string
+type vars struct {
+	InstanceID    string
+	InstanceIndex string
 }
 
 func IndexHandler(w http.ResponseWriter, r *http.Request) {
-
-	instance_id := os.Getenv("CF_INSTANCE_GUID")
-	instance_index := os.Getenv("CF_INSTANCE_INDEX")
-	template_file, err := ioutil.ReadFile("index.html.template")
+	id := os.Getenv("CF_INSTANCE_GUID")
+	index := os.Getenv("CF_INSTANCE_INDEX")
+	f, err := ioutil.ReadFile("index.html.template")
 	if err != nil {
 		panic(err)
 	}
-	tmpl, err := template.New("goose").Parse(string(template_file))
+	tmpl, err := template.New("goose").Parse(string(f))
 	if err != nil {
 		panic(err)
 	}
-	err = tmpl.Execute(w, index_vars{Instance_id: instance_id, Instance_index: instance_index})
+	err = tmpl.Execute(w, vars{InstanceID: id, InstanceIndex: index})
 	if err != nil {
 		panic(err)
 	}

--- a/go/main.go
+++ b/go/main.go
@@ -1,27 +1,33 @@
 package main
 
 import (
-	"net/http"
-        "io/ioutil"
 	"html/template"
+	"io/ioutil"
+	"net/http"
 	"os"
 )
 
 type index_vars struct {
-	Instance_id string
+	Instance_id    string
 	Instance_index string
 }
 
 func IndexHandler(w http.ResponseWriter, r *http.Request) {
 
-    instance_id := os.Getenv("CF_INSTANCE_GUID")
+	instance_id := os.Getenv("CF_INSTANCE_GUID")
 	instance_index := os.Getenv("CF_INSTANCE_INDEX")
-	template_file, err :=  ioutil.ReadFile("index.html.template")
-	if err != nil { panic(err) }
-        tmpl, err := template.New("goose").Parse(string(template_file))
-	if err != nil { panic(err) }
+	template_file, err := ioutil.ReadFile("index.html.template")
+	if err != nil {
+		panic(err)
+	}
+	tmpl, err := template.New("goose").Parse(string(template_file))
+	if err != nil {
+		panic(err)
+	}
 	err = tmpl.Execute(w, index_vars{Instance_id: instance_id, Instance_index: instance_index})
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 }
 
 func main() {

--- a/go/main.go
+++ b/go/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"html/template"
-	"io/ioutil"
 	"net/http"
 	"os"
 )
@@ -12,19 +11,13 @@ type instanceInfo struct {
 	InstanceIndex string
 }
 
-var info instanceInfo
+var (
+	info instanceInfo
+	tmpl *template.Template
+)
 
 func IndexHandler(w http.ResponseWriter, r *http.Request) {
-	f, err := ioutil.ReadFile("index.html.template")
-	if err != nil {
-		panic(err)
-	}
-	tmpl, err := template.New("goose").Parse(string(f))
-	if err != nil {
-		panic(err)
-	}
-	err = tmpl.Execute(w, info)
-	if err != nil {
+	if err := tmpl.Execute(w, info); err != nil {
 		panic(err)
 	}
 }
@@ -34,6 +27,8 @@ func main() {
 		InstanceID:    os.Getenv("CF_INSTANCE_GUID"),
 		InstanceIndex: os.Getenv("CF_INSTANCE_INDEX"),
 	}
+
+	tmpl = template.Must(template.ParseFiles("index.html.template"))
 
 	http.HandleFunc("/", IndexHandler)
 	http.Handle("/public/", http.StripPrefix("/public/", http.FileServer(http.Dir("public"))))

--- a/go/template.go
+++ b/go/template.go
@@ -1,3 +1,6 @@
+package main
+
+const gooseTemplate = `
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -33,3 +36,4 @@
 </footer>
 </body>
 </html>
+`


### PR DESCRIPTION
👋Hey there!

I cleaned up the Go example a bit.  This is broke into separate commits so you can see each step along the way, but you probably want to squash them prior to merging.

As an added benefit, it's nearly twice as fast!

Before
```
➜ hey http://localhost:8080

Summary:
  Total:	0.0128 secs
  Slowest:	0.0094 secs
  Fastest:	0.0003 secs
  Average:	0.0025 secs
  Requests/sec:	15603.2822

  Total data:	146400 bytes
  Size/request:	732 bytes
```

After
```
➜ hey http://localhost:8080

Summary:
  Total:	0.0077 secs
  Slowest:	0.0066 secs
  Fastest:	0.0001 secs
  Average:	0.0014 secs
  Requests/sec:	25987.7792

  Total data:	146800 bytes
  Size/request:	734 bytes
```
