### PR TITLE
Update project file to dotnet version that works with buildpack 2.2.7

### DIFF
--- a/dotnetcore/hello-goose/hello-goose.csproj
+++ b/dotnetcore/hello-goose/hello-goose.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.All"  />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />


### PR DESCRIPTION
Hi - I couldn't get this to work on Pez without changing the dotnet version. Assuming PCF One is using the latest buildpacks, I don't think it will work there either. 
